### PR TITLE
Upgrade to Terraform 0.12

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,21 @@
 data "aws_ssm_parameter" "read" {
-  count = "${var.enabled == "true" ? length(var.parameter_read) : 0}"
-  name  = "${element(var.parameter_read, count.index)}"
+  count = var.enabled ? length(var.parameter_read) : 0
+  name  = element(var.parameter_read, count.index)
 }
 
 resource "aws_ssm_parameter" "default" {
-  count           = "${var.enabled == "true" ? length(var.parameter_write) : 0}"
-  name            = "${lookup(var.parameter_write[count.index], "name")}"
-  description     = "${lookup(var.parameter_write[count.index], "description", lookup(var.parameter_write[count.index], "name"))}"
-  type            = "${lookup(var.parameter_write[count.index], "type", "SecureString")}"
-  key_id          = "${lookup(var.parameter_write[count.index], "type", "SecureString") == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""}"
-  value           = "${lookup(var.parameter_write[count.index], "value")}"
-  overwrite       = "${lookup(var.parameter_write[count.index], "overwrite", "false")}"
-  allowed_pattern = "${lookup(var.parameter_write[count.index], "allowed_pattern", "")}"
-  tags            = "${var.tags}"
+  count = var.enabled ? length(var.parameter_write) : 0
+  name  = tolist(var.parameter_write)[count.index]["name"]
+  description = lookup(
+    tolist(var.parameter_write)[count.index],
+    "description",
+    tolist(var.parameter_write)[count.index]["name"],
+  )
+  type            = lookup(tolist(var.parameter_write)[count.index], "type", "SecureString")
+  key_id          = lookup(tolist(var.parameter_write)[count.index], "type", "SecureString") == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""
+  value           = tolist(var.parameter_write)[count.index]["value"]
+  overwrite       = lookup(tolist(var.parameter_write)[count.index], "overwrite", "false")
+  allowed_pattern = lookup(tolist(var.parameter_write)[count.index], "allowed_pattern", "")
+  tags            = var.tags
 }
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,20 +1,43 @@
 # Splitting and joining, and then compacting a list to get a normalised list
 locals {
-  name_list  = "${compact(concat(split("${var.split_delimiter}",join("${var.split_delimiter}", aws_ssm_parameter.default.*.name)), split("${var.split_delimiter}",join("${var.split_delimiter}", data.aws_ssm_parameter.read.*.name))))}"
-  value_list = "${compact(concat(split("${var.split_delimiter}",join("${var.split_delimiter}", aws_ssm_parameter.default.*.value)), split("${var.split_delimiter}",join("${var.split_delimiter}", data.aws_ssm_parameter.read.*.value))))}"
+  name_list = compact(
+    concat(
+      split(
+        var.split_delimiter,
+        join(var.split_delimiter, aws_ssm_parameter.default.*.name),
+      ),
+      split(
+        var.split_delimiter,
+        join(var.split_delimiter, data.aws_ssm_parameter.read.*.name),
+      ),
+    ),
+  )
+  value_list = compact(
+    concat(
+      split(
+        var.split_delimiter,
+        join(var.split_delimiter, aws_ssm_parameter.default.*.value),
+      ),
+      split(
+        var.split_delimiter,
+        join(var.split_delimiter, data.aws_ssm_parameter.read.*.value),
+      ),
+    ),
+  )
 }
 
 output "names" {
-  value       = "${local.name_list}"
+  value       = local.name_list
   description = "A list of all of the parameter names"
 }
 
 output "values" {
   description = "A list of all of the parameter values"
-  value       = "${local.value_list}"
+  value       = local.value_list
 }
 
 output "map" {
   description = "A map of the names and values created"
-  value       = "${zipmap(local.name_list, local.value_list)}"
+  value       = zipmap(local.name_list, local.value_list)
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,11 @@
 variable "parameter_read" {
-  type        = "list"
+  type        = list(string)
   description = "List of parameters to read from SSM. These must already exist otherwise an error is returned. Can be used with `parameter_write` as long as the parameters are different."
   default     = []
 }
 
 variable "parameter_write" {
-  type = "list"
+  type = list(string)
 
   description = <<DESC
   List of maps with the Parameter values in this format.
@@ -20,29 +20,31 @@ variable "parameter_write" {
   }]
 DESC
 
+
   default = []
 }
 
 variable "tags" {
-  type        = "map"
-  default     = {}
+  type = map(string)
+  default = {}
   description = "Map containing tags that will be added to the parameters"
 }
 
 variable "kms_arn" {
-  type        = "string"
-  default     = ""
+  type = string
+  default = ""
   description = "The ARN of a KMS key used to encrypt and decrypt SecretString values"
 }
 
 variable "enabled" {
-  type        = "string"
-  default     = "true"
+  type        = bool
+  default     = true
   description = "Set to `false` to prevent the module from creating and accessing any resources"
 }
 
 variable "split_delimiter" {
-  type        = "string"
-  default     = "~^~"
+  type = string
+  default = "~^~"
   description = "A delimiter for splitting and joining lists together for normalising the output"
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
#### what

Run `terraform 0.12upgrade` against codebase. Note that due to Terraform
0.12 now using sets, we call `tolist` to workaround [1]

[1] https://github.com/terraform-providers/terraform-provider-aws/issues/7522

#### testing

I have tested this using Terraform 0.12.6