### PR TITLE
Fix warnings in the newest versions of Terraform #11

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,16 +1,16 @@
 data "aws_ssm_parameter" "read" {
-  count = "${var.enabled == "true" ? length(var.parameter_read) : 0}"
-  name  = "${element(var.parameter_read, count.index)}"
+  count = var.enabled == "true" ? length(var.parameter_read) : 0
+  name  = element(var.parameter_read, count.index)
 }
 
 resource "aws_ssm_parameter" "default" {
-  count           = "${var.enabled == "true" ? length(var.parameter_write) : 0}"
-  name            = "${lookup(var.parameter_write[count.index], "name")}"
-  description     = "${lookup(var.parameter_write[count.index], "description", lookup(var.parameter_write[count.index], "name"))}"
-  type            = "${lookup(var.parameter_write[count.index], "type", "SecureString")}"
-  key_id          = "${lookup(var.parameter_write[count.index], "type", "SecureString") == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""}"
-  value           = "${lookup(var.parameter_write[count.index], "value")}"
-  overwrite       = "${lookup(var.parameter_write[count.index], "overwrite", "false")}"
-  allowed_pattern = "${lookup(var.parameter_write[count.index], "allowed_pattern", "")}"
-  tags            = "${var.tags}"
+  count           = var.enabled == "true" ? length(var.parameter_write) : 0
+  name            = lookup(var.parameter_write[count.index], "name")
+  description     = lookup(var.parameter_write[count.index], "description", lookup(var.parameter_write[count.index], "name"))
+  type            = lookup(var.parameter_write[count.index], "type", "SecureString")
+  key_id          = lookup(var.parameter_write[count.index], "type", "SecureString") == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""
+  value           = lookup(var.parameter_write[count.index], "value")
+  overwrite       = lookup(var.parameter_write[count.index], "overwrite", "false")
+  allowed_pattern = lookup(var.parameter_write[count.index], "allowed_pattern", "")
+  tags            = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,11 +1,11 @@
 variable "parameter_read" {
-  type        = "list"
+  type        = list
   description = "List of parameters to read from SSM. These must already exist otherwise an error is returned. Can be used with `parameter_write` as long as the parameters are different."
   default     = []
 }
 
 variable "parameter_write" {
-  type = "list"
+  type = list
 
   description = <<DESC
   List of maps with the Parameter values in this format.
@@ -24,25 +24,25 @@ DESC
 }
 
 variable "tags" {
-  type        = "map"
+  type        = map
   default     = {}
   description = "Map containing tags that will be added to the parameters"
 }
 
 variable "kms_arn" {
-  type        = "string"
+  type        = string
   default     = ""
   description = "The ARN of a KMS key used to encrypt and decrypt SecretString values"
 }
 
 variable "enabled" {
-  type        = "string"
+  type        = string
   default     = "true"
   description = "Set to `false` to prevent the module from creating and accessing any resources"
 }
 
 variable "split_delimiter" {
-  type        = "string"
+  type        = string
   default     = "~^~"
   description = "A delimiter for splitting and joining lists together for normalising the output"
 }


### PR DESCRIPTION
Issue number #11 alludes to several warnings that are thrown with the newest versions of Terraform. This pull request updates the code to drop several quotes that are no longer needed.

I'm currently on a Windows machine and don't have access to make at the moment, but am hoping that isn't too much of a blocker here.

- fix `Quoted type constraints are deprecated` warnings
- fix `Interpolation-only expressions are deprecated` warnings