### PR TITLE
Update providers and terraform versions settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,21 +125,22 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| terraform | >= 0.12 |
+| aws | >= 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -161,6 +162,7 @@ Available targets:
 | names | A list of all of the parameter names |
 | values | A list of all of the parameter values |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,18 +1,19 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
-| local | ~> 1.2 |
-| null | ~> 2.0 |
-| template | ~> 2.0 |
+| terraform | >= 0.12 |
+| aws | >= 2.0 |
+| local | >= 1.2 |
+| null | >= 2.0 |
+| template | >= 2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -34,3 +35,4 @@
 | names | A list of all of the parameter names |
 | values | A list of all of the parameter values |
 
+<!-- markdownlint-restore -->

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,21 @@
 terraform {
-  required_version = ">= 0.12.0, < 0.14.0"
-
+  required_version = ">= 0.12"
   required_providers {
-    aws      = "~> 2.0"
-    template = "~> 2.0"
-    local    = "~> 1.2"
-    null     = "~> 2.0"
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 2.0"
+    }
+    template = {
+      source  = "hashicorp/template"
+      version = ">= 2.0"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 1.3"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     local = {
       source  = "hashicorp/local"
-      version = ">= 1.3"
+      version = ">= 1.2"
     }
     null = {
       source  = "hashicorp/null"


### PR DESCRIPTION
## what
* Update terraform and provider version requirements

## why
* 3.0 AWS provider is already here and we should be able to use the module with it

