### PR TITLE
Loosen the AWS provider requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,12 +125,13 @@ Available targets:
 
 ```
 <!-- markdownlint-restore -->
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
@@ -139,7 +140,7 @@ Available targets:
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -161,6 +162,7 @@ Available targets:
 | names | A list of all of the parameter names |
 | values | A list of all of the parameter values |
 
+<!-- markdownlint-restore -->
 
 
 

--- a/docs/terraform.md
+++ b/docs/terraform.md
@@ -1,9 +1,10 @@
+<!-- markdownlint-disable -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | terraform | >= 0.12.0, < 0.14.0 |
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 | local | ~> 1.2 |
 | null | ~> 2.0 |
 | template | ~> 2.0 |
@@ -12,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| aws | ~> 2.0 |
+| aws | >= 2.0 |
 
 ## Inputs
 
@@ -34,3 +35,4 @@
 | names | A list of all of the parameter names |
 | values | A list of all of the parameter values |
 
+<!-- markdownlint-restore -->

--- a/versions.tf
+++ b/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = ">= 0.12.0, < 0.14.0"
 
   required_providers {
-    aws      = "~> 2.0"
+    aws      = ">= 2.0"
     template = "~> 2.0"
     local    = "~> 1.2"
     null     = "~> 2.0"


### PR DESCRIPTION
## what
Loosen the AWS provider requirement

## why
Required versions was loosened for running Terraform 0.13 which wants
to use the AWS v3 provider, allow it to do so.

Otherwise we need to pin any module that calls terraform-aws-ssm-parameter-store to use the v2 provider.