### PR TITLE
Flag sensitive values as described in terraform 0.14 upgrade

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -48,11 +48,13 @@ output "names" {
 output "values" {
   description = "A list of all of the parameter values"
   value       = local.value_list
+  sensitive   = true
 }
 
 output "map" {
   description = "A map of the names and values created"
   value       = zipmap(local.name_list, local.value_list)
+  sensitive   = true
 }
 
 output "arn_map" {

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.0"
+  required_version = ">= 0.14.0"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 2.0"
+      version = ">= 3.0"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
## what
* Fixing problem with terraform 0.14 sensitive output variables

## why
When I wanted to use module with terraform 0.14 I got error:
```
Error: Output refers to sensitive values

  on .terraform/modules/akamai_ssm_data/outputs.tf line 48:
  48: output "values" {

Expressions used in outputs can only refer to sensitive values if the
sensitive attribute is true.


Error: Output refers to sensitive values

  on .terraform/modules/akamai_ssm_data/outputs.tf line 53:
  53: output "map" {

Expressions used in outputs can only refer to sensitive values if the
sensitive attribute is true.
```
To Fix this issue we need to add `sensitive   = true` flag to both outputs. Now Terraform will not display sensitive values, but we can still use them in other modules. Look into provided link in `references` if you want to know more.

## references
* https://www.terraform.io/upgrade-guides/0-14.html#sensitive-values-in-plan-output
* Fixing #28 

