### PR TITLE
Add option to ignore changes

### DIFF
--- a/README.yaml
+++ b/README.yaml
@@ -55,11 +55,12 @@ usage: |2-
 
     parameter_write = [
       {
-        name        = "/cp/prod/app/database/master_password"
-        value       = "password1"
-        type        = "String"
-        overwrite   = "true"
-        description = "Production database master password"
+        name           = "/cp/prod/app/database/master_password"
+        value          = "password1"
+        type           = "String"
+        overwrite      = "true"
+        description    = "Production database master password"
+        ignore_changes = "false"
       }
     ]
 

--- a/main.tf
+++ b/main.tf
@@ -21,4 +21,13 @@ resource "aws_ssm_parameter" "default" {
   overwrite       = each.value.overwrite
   allowed_pattern = each.value.allowed_pattern
   tags            = var.tags
+
+  dynamic "lifecycle" {
+    for_each = each.value.ignore_changes == "true" ? ["ignore_changes"] : []
+    content {
+      ignore_changes = [
+        value
+      ]
+    }
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -22,12 +22,7 @@ resource "aws_ssm_parameter" "default" {
   allowed_pattern = each.value.allowed_pattern
   tags            = var.tags
 
-  dynamic "lifecycle" {
-    for_each = each.value.ignore_changes == "true" ? ["ignore_changes"] : []
-    content {
-      ignore_changes = [
-        value
-      ]
-    }
+  lifecycle {
+    ignore_changes = each.value.ignore_changes == "true" ? [value] : []
   }
 }


### PR DESCRIPTION
## what
* This change gives possibility to add lifecycle rule to ignore changes in value - useful when we are unable to provide secrets via Terraform, but we want to have them securely stored

## why
* Our OIDC provider doesn't have terraform provider, so we are unable to pass secrets in secure way. Also we don't want to persist secrets inside git repository
* This change will create SSM parameter, but will also ignore future changes to it. Thanks to that we are able to provide correct credentials to SSM via AWS console.

