### PR TITLE
update outputs to work with ignore_value_changes ssm parameters

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,16 +1,16 @@
 # Splitting and joining, and then compacting a list to get a normalised list
 locals {
-  name_list = compact(concat(keys(local.parameter_write), local.parameter_read))
+  name_list = compact(concat(keys(local.parameter_write), keys(local.parameter_write_ignore_values), local.parameter_read))
 
   value_list = compact(
     concat(
-      [for p in aws_ssm_parameter.default : p.value], data.aws_ssm_parameter.read.*.value
+      [for p in aws_ssm_parameter.default : p.value], [for p in aws_ssm_parameter.ignore_value_changes : p.value], data.aws_ssm_parameter.read.*.value
     )
   )
 
   arn_list = compact(
     concat(
-      [for p in aws_ssm_parameter.default : p.arn], data.aws_ssm_parameter.read.*.arn
+      [for p in aws_ssm_parameter.default : p.arn], [for p in aws_ssm_parameter.ignore_value_changes : p.arn], data.aws_ssm_parameter.read.*.arn
     )
   )
 }


### PR DESCRIPTION
## what
* Update outputs to include the name and values of the `ignore_value_changes` parameters.

## why
* Output arguments for the `ignore_value_changes` resource