### PR TITLE
chore: add overwrite argument back

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ We deliver 10x the value for a fraction of the cost of a full-time engineer. Our
 [![README Commercial Support][readme_commercial_support_img]][readme_commercial_support_link]
 ## License
 
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg?style=for-the-badge)](https://opensource.org/licenses/Apache-2.0)
 
 See [LICENSE](LICENSE) for full details.
 

--- a/main.tf
+++ b/main.tf
@@ -14,11 +14,17 @@ resource "aws_ssm_parameter" "default" {
   for_each = local.parameter_write
   name     = each.key
 
-  description     = each.value.description
-  type            = each.value.type
-  tier            = each.value.tier
-  key_id          = each.value.type == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""
-  value           = each.value.value
+  description = each.value.description
+  type        = each.value.type
+  tier        = each.value.tier
+  key_id      = each.value.type == "SecureString" && length(var.kms_arn) > 0 ? var.kms_arn : ""
+  value       = each.value.value
+  # Note on the deprecation warning:
+  # Configurations expecting the standard update flow will need to keep overwrite = true set
+  # until this becomes the default behavior in v6.0.0. Removing it in v5.X will result in
+  # the default value of false, preventing the parameter value from being updated.
+  # Source: https://github.com/hashicorp/terraform-provider-aws/issues/25636#issuecomment-1623661159
+  overwrite       = each.value.overwrite
   allowed_pattern = each.value.allowed_pattern
   data_type       = each.value.data_type
 


### PR DESCRIPTION
## what

- Unfortunately, we have to add the `overwrite` argument back due to the confusion of its deprecation:
```
Lastly, and unfortunately, configurations expecting the standard update flow will need to keep overwrite = true set until this becomes the default behavior in v6.0.0. Removing it in v5.X will result in the default value of false, preventing the parameter value from being updated, causing persistent differences.
```

## why

- Prevent undesired behaviour.

## references

- https://github.com/hashicorp/terraform-provider-aws/issues/25636#issuecomment-1623661159